### PR TITLE
change case of bot name to correct rebuilding of CS bot

### DIFF
--- a/chatbot-server/sarah.yaml
+++ b/chatbot-server/sarah.yaml
@@ -12,7 +12,7 @@ tiers:
       weight: 1
       cs_host: localhost
       cs_port: 1024
-      cs_botname: sarah
+      cs_botname: Sarah
   - type: chatbot.characters.ddg.DDG
     args:
       id: ddg

--- a/chatbot-server/src/chatbot/characters/cs.py
+++ b/chatbot-server/src/chatbot/characters/cs.py
@@ -234,6 +234,6 @@ class CSCharacter(Character):
 if __name__ == '__main__':
     from chatbot.server.session import Session
     s = Session('id')
-    c = CSCharacter('id', 'name', 1, 1, 'localhost', '2048', 'sarah')
+    c = CSCharacter('id', 'name', 1, 1, 'localhost', '2048', 'Sarah')
     answer = c.respond('make sense', 'en', s, False, '1')
     print answer


### PR DESCRIPTION
@wenwei-dev It looks like a capitalization issue with the bot name was keeping the CS bot from successfully rebuilding when triggered by a git repo update. I've corrected but want to make sure this is the right thing to do. Thanks.